### PR TITLE
Add Elastic

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ list (in alphabetical order).
 * BMAT [Open positions](https://bmat.bamboohr.com/jobs/)
 * Cloudbees [Open positions](https://www.cloudbees.com/careers/job)
 * Ebury [Open positions](https://careers.ebury.com/)
+* Elastic [Open positions](https://www.elastic.co/about/careers/)
 * Fastly [Open positions](https://www.fastly.com/about/careers)
 * Form3 [Open positions](https://form3.tech/careers)
 * GitHub [Open positions](https://github.com/about/careers)


### PR DESCRIPTION
Elastic hires 100% remote and offers full-time contracts through its spanish subsidiary. 28 days of paid vacations.

2 offices available in Spain (Barcelona, Madrid) for when you feel lonely (no mandatory attendance).

5-day onboarding (CA, Palo Alto) and 2 yearly 5-day events (North America, Europe).

Digital nomads are welcome.
