### PR TITLE
Add Manfred

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ list (in alphabetical order). Try to be brief to keep the list manageable.
 * Vizzuality [Open positions](https://vizzuality.bamboohr.com/jobs/)
 * XING (occasional travels to the offices in Barcelona or Valencia) [Open positions](https://www.xing.com/jobs/search?page=1&utf8=%E2%9C%93&nrs=1&sc_o=jobs_search_button&keywords=xing&location=barcelona&radius=)
 * Z1 [Open positions](https://z1.digital/careers)
+
+# Others
+
+* Manfred [Open positions](https://github.com/getmanfred/offers/wiki) Manfred is
+  a recruiting company. Offers marked as `FULL REMOTE` and with a salary in euro
+  comply with the conditions stated above.


### PR DESCRIPTION
I asked Manfred about their offers page in the following discussion:

https://github.com/getmanfred/offers/issues/2
https://github.com/remote-es/remotes/issues/18

It does seem that their job listing lists *clearly* remote offers with Spanish contracts, so we *could* add them. Opening this as a PR for review because I'm not sure it's a good idea to include it.

Thoughts?