### PR TITLE
Add Splash

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ with a justification) or open an issue.
 * Red Hat [Open positions](https://global-redhat.icims.com/jobs/search?ss=1&searchLocation=13549--Remote)
 * reply.ai [Open positions](https://replyai.bamboohr.com/jobs/)
 * Rindus [Open positions](https://rindus-jobs.personio.de/search?language=en&query=remote)
+* Splash [Open positions](https://splashthat.com/careers)
 * Splice Machine [Open positions](https://jobs.lever.co/splicemachine/)
 * Stuart [Open positions](https://stuart.com/careers/)
 * Twilio [Open positions](https://boards.greenhouse.io/twilio/)


### PR DESCRIPTION
Hi there 👋 

We just added 2 engineering positions that allow for full remote. Currently, they show up under the "Madrid" filter. I'm going to ask our team to add a new label "Remote" where they'll show up as well, so it'd be much more clear.

If there's anything else I can do to improve or adjust to guidelines, let me know. Thank you!