### PR TITLE
Add Empathy.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ with a justification) or open an issue.
 * Ebury [Open positions](https://careers.ebury.com/)
 * Elastic [Open positions](https://www.elastic.co/about/careers/)
 * Electromaps [Open positions](https://www.electromaps.com/articulo/unete-al-equipo-electromaps)
+* Empathy.co [Open positions](https://www.empathy.co/company/careers/)
 * Eventbrite [Open positions](https://www.eventbritecareers.com/jobs/search?page=1&country_codes%5B%5D=ES&cities%5B%5D=Remote&query=)
 * Exoticca [Open positions](https://apply.workable.com/exoticca/)
 * Factorial [Open positions](https://factorialhr.com/join-factorial)


### PR DESCRIPTION
Adding [Empathy.co](https://www.empathy.co) to the list.

Company based in Gijón, but has been operating fully remote for a while.