### PR TITLE
Add Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ with a justification) or open an issue.
 * Ebury [Open positions](https://careers.ebury.com/)
 * Elastic [Open positions](https://www.elastic.co/about/careers/)
 * Electromaps [Open positions](https://www.electromaps.com/articulo/unete-al-equipo-electromaps)
+* Element [Open positions](https://element.io/careers)
 * Empathy.co [Open positions](https://www.empathy.co/company/careers/)
 * Eventbrite [Open positions](https://www.eventbritecareers.com/jobs/search?page=1&country_codes%5B%5D=ES&cities%5B%5D=Remote&query=)
 * Exoticca [Open positions](https://apply.workable.com/exoticca/)


### PR DESCRIPTION
Adds [Element](https://element.io/), based in the UK but hiring internationally.

Most positions are remote, with a few exceptions, all clearly marked on the job board. Everything else applies: Spanish contract (via an intermediary company), normal office hours, light travel requirements (annual company offsite, sometimes an additional one to spend a few days with your team)...