### PR TITLE
Changed verbio url to careers

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ See [OWNERS](OWNERS.md) for details about the maintenance of the project.
 * Typeform (View individual job offers to check for remote) [Open positions](https://www.typeform.com/careers/)
 * Unimedia Technology [Open positions](https://www.linkedin.com/jobs/search/?f_C=13029092)
 * UserZoom [Open positions](https://www.userzoom.com/careers?uuid=elia)
-* Verbio (View individual job offers to check for remote) [Open positions](https://www.verbio.com/company/)
+* Verbio (View individual job offers to check for remote) [Open positions](https://www.verbio.com/careers/)
 * Vinissimus [Open positions](https://www.linkedin.com/company/vinissimus/jobs/)
 * Vistaprint (All offers are remote) [Open positions](https://jobs.vistaprint.com/Vistaprint/go/Barcelona%2C-Spain/7789500/)
 * Vitaance (Monthly trips to Barcelona/Madrid) [Open positions](https://vitaance.jobs.personio.com/)


### PR DESCRIPTION
The 'verbio' url pointed to a route that did not correspond to careers.