### PR TITLE
Remove Cobee

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ The following companies offer remote jobs and hire in Spain:
 * Clidrive (All technical offers are remote) [Open positions](https://clidrive.jobs.personio.com/)
 * Cloudbees [Open positions](https://www.cloudbees.com/careers/job)
 * Clovr Labs [Open positions](https://clovrlabs.teamtailor.com/#section-jobs)
-* Cobee (All technical offers are remote) [Open positions](https://cobee.teamtailor.com/jobs)
 * Codeworks [Open positoins](https://www.linkedin.com/school/codeworks/jobs/)
 * codi cooperatiu [Open positions](https://codi.coop/en/about-us/busquem-socies/)
 * Codurance (View individual job offers to check for remote) (Core office hours/overlap between 10:00 and 17:00 CEST) [Open positions](https://www.codurance.com/careers/current-roles?hsCtaTracking=fd7530a4-dec7-4756-a255-81b5624a506b%7Ca53de7f3-e646-4f7b-997a-28f786445c95)


### PR DESCRIPTION
# Removing companies

Looks like [Cobee is now part of Pluxee] (https://cobee.io/blog/cobee-a-pluxee-company/) and Pluxee positions in Spain are not fully remote. All of them are posted as "Hybrid - Madrid", for [example](https://pluxee.wd3.myworkdayjobs.com/en-US/Pluxee_Career_Site/details/Software-Engineer_R3878?locationCountry=bd34c524a6a04ae6915f5d96fa086199).