### PR TITLE
Fix Codeworks broken careers link

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The following companies offer remote jobs and hire in Spain:
 * Clidrive (All technical offers are remote) [Open positions](https://clidrive.jobs.personio.com/)
 * Cloudbees [Open positions](https://www.cloudbees.com/careers/job)
 * Clovr Labs [Open positions](https://clovrlabs.teamtailor.com/#section-jobs)
-* Codeworks [Open positoins](https://www.linkedin.com/school/codeworks/jobs/)
+* Codeworks [Open positions](https://www.linkedin.com/school/codeworks/jobs/)
 * codi cooperatiu [Open positions](https://codi.coop/en/about-us/busquem-socies/)
 * Codurance (View individual job offers to check for remote) (Core office hours/overlap between 10:00 and 17:00 CEST) [Open positions](https://www.codurance.com/careers/current-roles?hsCtaTracking=fd7530a4-dec7-4756-a255-81b5624a506b%7Ca53de7f3-e646-4f7b-997a-28f786445c95)
 * Colvin (All offers are remote) [Open positions](https://www.linkedin.com/company/colvin/jobs/)


### PR DESCRIPTION
## Summary
- Fix typo in Codeworks careers URL (positoins -> positions)