### PR TITLE
Remove Personio

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,6 @@ The following companies offer remote jobs and hire in Spain:
 * PayFit (All offers are remote) [Open positions](https://payfit.com/en/careers/)
 * PcComponentes [Open positions](https://www.pccomponentes.com/trabaja-con-nosotros)
 * Pearson [Open positions](https://pearson.jobs/jobs/)
-* Personio (View individual job offers to check for remote) [Open positions](https://www.personio.com/about-personio/careers/#see-our-open-roles)
 * Phiture [Open positions](https://boards.eu.greenhouse.io/phiture)
 * Plain Concepts [Open positions](https://www.plainconcepts.com/careers/)
 * Playtomic [Open positions](https://playtomic.jobs.personio.com)


### PR DESCRIPTION
Personio is no longer hiring remotely, switched to hybrid.

Example [job posting](https://www.personio.com/careers/256c9c42-b3a6-429a-a836-316ad8616bb6/):
> This role requires 2 days per week in the office and is based in Madrid.